### PR TITLE
update Go opensearch Utils, 修复签名失败问题.

### DIFF
--- a/util/golang/service/service.go
+++ b/util/golang/service/service.go
@@ -63,10 +63,17 @@ func getSignature(request *tea.Request, accessKeySecret string) string {
 	if !strings.Contains(resource, "?") && len(request.Query) > 0 {
 		resource += "?"
 	}
-	for key, value := range request.Query {
+	queryKeys := make([]string, len(request.Query))
+	for k,_ := range request.Query {
+		queryKeys = append(queryKeys, k)
+	}
+	sort.Strings(queryKeys)
+	for _, key := range queryKeys {
+		value := request.Query[key]
 		if value != nil {
 			tmp := url.QueryEscape(tea.StringValue(value))
 			tmp = strings.ReplaceAll(tmp, "'", "%27")
+			tmp = strings.ReplaceAll(tmp, "+", "%20")
 			if strings.HasSuffix(resource, "?") {
 				resource = resource + key + "=" + tmp
 			} else {


### PR DESCRIPTION
**1. fix GoMaps 无序状态导致签名失败问题.  原提交 https://github.com/alibabacloud-go/opensearch-util/pull/1**
因为 golang 的 map 是无序的，所以这里直接获取时，会导致同样的参数得到的 resource 变量有可能不一样，致使得到的签名不一样。

**2.修复 Query 场景 搜索词存在空格场景 原提交 https://github.com/alibabacloud-go/opensearch-util/pull/2**
对于 query=default:'测试' AND tag:'1' , 会把空格转换成加号(+)导致签名错误