### PR TITLE
fix: OpenSearchUtil java artifactId

### DIFF
--- a/util/Teafile
+++ b/util/Teafile
@@ -7,7 +7,7 @@
 		"go": "github.com/alibabacloud-go/opensearch-util/service:v1.0.0",
 		"csharp": "AlibabaCloud.OpenSearchUtil:0.0.1",
 		"ts": "@alicloud/opensearch-util:^1.0.0",
-		"java": "com.aliyun:opensearch-util:0.0.1",
+		"java": "com.aliyun:opensearchutil:0.0.1",
 		"php": "alibabacloud/opensearch-util:^0.1",
 		"python": "alibabacloud_opensearch_util:0.0.1"
 	},


### PR DESCRIPTION
https://oss.sonatype.org/#nexus-search;quick~opensearch-util
![image](https://user-images.githubusercontent.com/25344334/141964009-f17b50c4-f450-4867-843c-991a20fd2ec2.png)

[https://oss.sonatype.org/#nexus-search;quick~opensearchutil](https://oss.sonatype.org/#nexus-search;quick~opensearchutil)
![image](https://user-images.githubusercontent.com/25344334/141963447-866518c3-3bc2-48a5-94b3-5177a4b1d7d1.png)

As above show,`opensearch-util` doesn't exists in maven repository.Its correct name is `opensearchutil`.